### PR TITLE
Bring back default Observable wrapping of intents.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxium",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A moderately reactive Flux implementation wrapped around Nuclear JS.",
   "main": "lib/fluxium.js",
   "repository": {

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,10 @@
+import Rx from 'rx'
+import _ from 'lodash'
+
+export default function makeObservable(value) {		
+	if (typeof _.get(value, 'subscribe') !== 'function') {		
+		value = typeof _.get(value, 'then') === 'function' ? Rx.Observable.fromPromise(value) : Rx.Observable.just(value);		
+	}
+
+	return value;		
+}

--- a/src/wrapIntents.js
+++ b/src/wrapIntents.js
@@ -4,6 +4,7 @@ import mapValues from 'lodash/object/mapValues'
 import isPlainObject from 'lodash/lang/isPlainObject'
 import every from 'lodash/collection/every'
 import includes from 'lodash/collection/includes'
+import makeObservable from './util'
 import log from './log'
 
 export default function wrapIntents({ intents, reactor, handleError }) {
@@ -33,7 +34,7 @@ function wrapIntent({ intent, name, reactor, handleError }) {
 		log(...[`Intent called: ${name}.`]
 			.concat(payload ? ['Payload:', payload] : []))
 
-		var result = intent(payload, evaluate)
+		var result = makeObservable(intent(payload, evaluate))
 
 		invariant(
 			typeof result.subscribe === 'function',
@@ -101,5 +102,3 @@ function dispatch({ reactor, type, payload }) {
 
 	reactor.dispatch(type, payload)
 }
-
-


### PR DESCRIPTION
Intents are once again passed through a method to wrap any non-observable in an observable. This allows use of simple promises without explicitly wrapping them in an`Observable.fromPromise` call. Plain objects are wrapped in an `Observable.just`.
